### PR TITLE
Fixes raschke testimony in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ resources.
 Kurt Raschke `noted in 2010`_::
 
   In a DOM-based implementation, it would be relatively easy […]
-  But lxml doesn't use text nodes; instead it uses and properties to hold text
-  content.
+  But lxml doesn't use text nodes; instead it uses [``text``] and [``tail``]
+  properties to hold text content.
 
 
 .. _snakesist: https://pypi.org/project/snakesist/


### PR DESCRIPTION
assuming that the attributes `text` and `tail` had been put inside of some markdown tags in his original manuscript also and were then run through a bad converter.