### PR TITLE
A few refinements of the CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,13 @@ authors:
   - family-names: Sachsenheim
     given-names: Frank
 license: AGPL-3.0
+contact:
+  - email: delb-project@posteo.net
+    website: https://github.com/delb-xml
+license: AGPL-3.0-only
+repository-code: https://github.com/delb-xml/delb-py/releaes/tag/0.3.0
+url: https://delb.readthedocs.io/en/0.3.0/
 version: 0.3.0
-repository-code: https://github.com/delb-xml/delb-py
 date-released: 2022-01-31
 
 ...

--- a/CITATION.cff.tmpl
+++ b/CITATION.cff.tmpl
@@ -1,5 +1,9 @@
 ---
 
+# If you use this software, please use this metadata.
+# You can consult this website for further information:
+# https://citation-file-format.github.io/
+
 cff-version: 1.2.0
 type: software
 message: 🔥🌍🔥
@@ -7,9 +11,13 @@ title: delb
 authors:
   - family-names: Sachsenheim
     given-names: Frank
-license: AGPL-3.0
+contact:
+  - email: delb-project@posteo.net
+    website: https://github.com/delb-xml
+license: AGPL-3.0-only
+repository-code: https://github.com/delb-xml/delb-py/releaes/tag/_VERSION_
+url: https://delb.readthedocs.io/en/_VERSION_/
 version: _VERSION_
-repository-code: "https://github.com/delb-xml/delb-py"
 date-released: _DATE_
 
 ...


### PR DESCRIPTION
i added leftovers of previous proposals that were irresponsibly overseen. the license identifier is now [according to the spec](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#license) (it may be noteworthy that the examples there use deprecated identifiers from the SPDX License List). and there are more specific URLs.

the result was rendered and validated correctly on a local host.