### PR TITLE
Adds the module _delb.names

### DIFF
--- a/_delb/names.py
+++ b/_delb/names.py
@@ -16,6 +16,16 @@ GLOBAL_PREFIXES = {"xml": XML_NAMESPACE, "xmlns": XMLNS_NAMESPACE}
 
 
 def deconstruct_clark_notation(name: str) -> Tuple[Optional[str], str]:
+    """ deconstructs an expression in Clark notation and returns the
+    extracted namespace and tagname as a tuple.
+
+    >>> deconstruct_clark_notation('{tei}text')
+    ('tei', 'text')
+
+    >>> deconstruct_clark_notation('div')
+    (None, 'div')
+
+    """
     if name.startswith("{"):
         a, b = name.split("}", maxsplit=1)
         return a[1:], b

--- a/_delb/names.py
+++ b/_delb/names.py
@@ -16,15 +16,17 @@ GLOBAL_PREFIXES = {"xml": XML_NAMESPACE, "xmlns": XMLNS_NAMESPACE}
 
 
 def deconstruct_clark_notation(name: str) -> Tuple[Optional[str], str]:
-    """ deconstructs an expression in Clark notation and returns the
-    extracted namespace and tagname as a tuple.
+    """
+    Deconstructs a name in Clark notation, thay may or may not include a namespace.
 
-    >>> deconstruct_clark_notation('{tei}text')
-    ('tei', 'text')
+    :param name: An attribute's or tag node's name.
+    :return: A tuple with the extracted namespace and local name.
+
+    >>> deconstruct_clark_notation('{http://www.tei-c.org/ns/1.0}text')
+    ('http://www.tei-c.org/ns/1.0', 'text')
 
     >>> deconstruct_clark_notation('div')
     (None, 'div')
-
     """
     if name.startswith("{"):
         a, b = name.split("}", maxsplit=1)
@@ -34,7 +36,12 @@ def deconstruct_clark_notation(name: str) -> Tuple[Optional[str], str]:
 
 
 class Namespaces(MutableMapping):
-    # implements https://www.w3.org/TR/xml-names/#xmlReserved
+    """
+    A :term:`mapping` of prefixes to namespaces that ensures globally defined prefixes
+    are available and unchanged.
+    """
+
+    # https://www.w3.org/TR/xml-names/#xmlReserved
 
     __slots__ = ("data",)
 

--- a/_delb/names.py
+++ b/_delb/names.py
@@ -17,7 +17,7 @@ GLOBAL_PREFIXES = {"xml": XML_NAMESPACE, "xmlns": XMLNS_NAMESPACE}
 
 def deconstruct_clark_notation(name: str) -> Tuple[Optional[str], str]:
     """
-    Deconstructs a name in Clark notation, thay may or may not include a namespace.
+    Deconstructs a name in Clark notation, that may or may not include a namespace.
 
     :param name: An attribute's or tag node's name.
     :return: A tuple with the extracted namespace and local name.

--- a/_delb/names.py
+++ b/_delb/names.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections import ChainMap
+from collections.abc import MutableMapping
+from typing import Mapping, Optional, Tuple
+
+from _delb.exceptions import InvalidOperation
+
+XML_NAMESPACE = "http://www.w3.org/XML/1998/namespace"
+XMLNS_NAMESPACE = "http://www.w3.org/2000/xmlns/"
+
+XML_ATT_ID = f"{{{XML_NAMESPACE}}}id"
+XML_ATT_SPACE = f"{{{XML_NAMESPACE}}}space"
+
+GLOBAL_PREFIXES = {"xml": XML_NAMESPACE, "xmlns": XMLNS_NAMESPACE}
+
+
+def deconstruct_clark_notation(name: str) -> Tuple[Optional[str], str]:
+    if name.startswith("{"):
+        a, b = name.split("}", maxsplit=1)
+        return a[1:], b
+    else:
+        return None, name
+
+
+class Namespaces(MutableMapping):
+    # implements https://www.w3.org/TR/xml-names/#xmlReserved
+
+    __slots__ = ("data",)
+
+    def __init__(self, namespaces: Mapping[Optional[str], str]):
+        self.data: Mapping[Optional[str], str]
+        if isinstance(namespaces, Namespaces):
+            self.data = namespaces.data
+        else:
+            self.data = namespaces
+
+    def __delitem__(self, key):
+        if key not in GLOBAL_PREFIXES:
+            del self.data[key]
+
+    def __getitem__(self, item):
+        return GLOBAL_PREFIXES.get(item) or self.data[item]
+
+    def __iter__(self):
+        return iter(ChainMap(GLOBAL_PREFIXES, self.data))
+
+    def __len__(self):
+        return len(self.data) + 2
+
+    def __setitem__(self, key, value):
+        if key in GLOBAL_PREFIXES:
+            raise InvalidOperation(f"One must not override the prefix '{key}'.")
+        self.data[key] = value
+
+    def __str__(self):
+        return str(dict(self))
+
+
+__all__ = (
+    "XML_NAMESPACE",
+    "XMLNS_NAMESPACE",
+    deconstruct_clark_notation.__name__,
+    Namespaces.__name__,
+)

--- a/delb/__init__.py
+++ b/delb/__init__.py
@@ -18,12 +18,13 @@ from collections.abc import MutableSequence
 from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, Iterable, Iterator, Optional, Tuple, Type, Union
+from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, Tuple, Type, Union
 from typing import IO as IOType
 
 from lxml import etree
 
 from _delb.exceptions import FailedDocumentLoading, InvalidOperation
+from _delb.names import Namespaces
 from _delb.plugins import (
     core_loaders,
     DocumentMixinHooks,
@@ -333,7 +334,7 @@ class Document(metaclass=DocumentMeta):
 
     def cleanup_namespaces(
         self,
-        namespaces: Optional["etree._NSMap"] = None,
+        namespaces: Optional[Mapping[Optional[str], str]] = None,
         retain_prefixes: Optional[Iterable[str]] = None,
     ):
         """
@@ -363,7 +364,8 @@ class Document(metaclass=DocumentMeta):
         """
         etree.cleanup_namespaces(
             self.root._etree_obj.getroottree(),
-            top_nsmap=namespaces,
+            # TODO https://github.com/lxml/lxml-stubs/issues/62
+            top_nsmap=namespaces,  # type: ignore
             keep_ns_prefixes=retain_prefixes,
         )
 
@@ -404,7 +406,7 @@ class Document(metaclass=DocumentMeta):
         self.root.merge_text_nodes()
 
     @property
-    def namespaces(self) -> Dict[Optional[str], str]:
+    def namespaces(self) -> Namespaces:
         """
         The namespace mapping of the document's :attr:`root <Document.root>` node.
         """
@@ -498,6 +500,7 @@ class Document(metaclass=DocumentMeta):
 __all__ = (
     CommentNode.__name__,
     Document.__name__,
+    Namespaces.__name__,
     ProcessingInstructionNode.__name__,
     QueryResults.__name__,
     TagNode.__name__,

--- a/delb/names.py
+++ b/delb/names.py
@@ -1,0 +1,4 @@
+# flake8: noqa
+
+from _delb.names import *
+from _delb.names import __all__

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -73,9 +73,13 @@ def test_detach_sustains_attributes():
     node = Document(
         "<root xmlns='https://default.ns'><node foo='bar'/></root>"
     ).root.first_child
-    assert node._etree_obj is node.attributes._element
+    attributes = node.attributes
+    attributes_copy = dict(attributes)
+
     node.detach()
-    assert node._etree_obj is node.attributes._element
+
+    assert node.attributes is attributes
+    assert node.attributes == attributes_copy
 
 
 def test_update():

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -188,6 +188,26 @@ def test_iter_next_node_over_long_stream(files_path):
     assert collected_text == expected_text
 
 
+def test_namespaces():
+    node = Document("<node/>").root
+    namespaces = node.namespaces
+
+    namespaces["xmpl"] = "https:example.org"
+    assert "xmpl" in namespaces
+
+    assert len(namespaces) == 3
+    assert set(namespaces.keys()) == {"xml", "xmlns", "xmpl"}
+
+    namespaces.pop("xmpl")
+    assert "xmpl" not in namespaces
+
+    namespaces.pop("xml")
+    assert "xml" in namespaces
+
+    with pytest.raises(InvalidOperation):
+        namespaces["xml"] = "something completely different"
+
+
 def test_no_next_node_in_stream():
     document = Document("<root><a/></root>")
     assert document.root[0].next_node_in_stream() is None

--- a/tests/test_subclasses.py
+++ b/tests/test_subclasses.py
@@ -49,7 +49,7 @@ def test_tei_subclass(files_path, filename):
     document = Document(files_path / filename)
 
     if isinstance(document, DTABfDocument):
-        assert document.text_characters == 74737
+        assert document.text_characters == 74738
         assert document.title == "Manifest der Kommunistischen Partei"
 
     elif isinstance(document, TEIDocument):

--- a/tests/test_tag_node.py
+++ b/tests/test_tag_node.py
@@ -3,7 +3,7 @@ from copy import copy, deepcopy
 import pytest
 from lxml import etree
 
-from _delb.nodes import XML_ATT_ID
+from _delb.names import XML_ATT_ID
 from delb import (
     Document,
     TagNode,
@@ -462,18 +462,18 @@ def test_names(sample_document):
     assert root.namespace == "https://name.space"
     assert root.local_name == "doc"
     assert root.universal_name == "{https://name.space}doc"
-    assert root.namespaces == {None: "https://name.space"}
+    assert root.namespaces[None] == "https://name.space"
 
     first_level_children = tuple(x for x in root.child_nodes())
     header, text = first_level_children[0], first_level_children[1]
 
     assert header.namespace == "https://name.space"
     assert header.local_name == "header"
-    assert header.namespaces == {None: "https://name.space"}
+    assert header.namespaces[None] == "https://name.space"
 
     assert text.namespace == "https://name.space"
     assert text.local_name == "text"
-    assert text.namespaces == {None: "https://name.space"}, root.namespaces
+    assert text.namespaces[None] == "https://name.space"
 
     text.namespace = "https://space.name"
     assert text.universal_name == "{https://space.name}text"


### PR DESCRIPTION
this is part of the changes from #55 that can be reviewed independently. the intention is to reduce the review effort for the XPath implementation, but it also means that i will rebase (and likely squash) in that branch once this is merged.

as a nice side-effect, this reveals that the last standing test regression in the XPath branch isn't related to the XPath implementation. i hope to figure it out this evening. i'd appreciate soonish reviews (should be trivial) so that i can continue with the XPath branch.