### PR TITLE
A proposal for a roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,50 @@
+# Roadmap for delb-py
+
+## 0.4
+
+- all currently planned changes
+  - [here](https://github.com/delb-xml/delb-py/milestone/4)
+  - [and here](https://github.com/delb-xml/delb-py/milestone/3)
+- deprecate these features provided by *lxml*:
+  - `delb.Document.xslt`
+    - such feature would have to be implemented in a separate package
+  - `_delb.utils.register_namespace`
+    - to be functionally replaced with `namespace_declarations` on `TagNode` instances
+  - `_delb.plugins.http_ftp_loader`
+    - the `_delb.plugins.https_loader.https_loader` becomes `.we_get_requests.http_s_loader`
+  - ? what about the `_delb.plugins.core_loaders.tag_node_loader` and `.etree_loader` ?
+    - if that functionality shall be kept, then as optional
+  - the `parser` and `collapse_whitespace` argument to a `delb.Document`
+    - instead a `parser_options` argument is added that allows these arguments (for `lxml.etree.XMLParser` equivalents):
+      - `cleanup_namespaces` (`ns_clean`)
+      - `collapse_whitespace`
+      - `remove_nodes_of_type`, a container with subclasses of `NodeBase` (*various*)
+      - `resolve_entities` (*dito*)
+        - later to be replaced with more specific control
+      - `unplugged` (`no_network`)
+- include a first set of benchmarks
+
+## 0.5
+
+- a native implementation of data serialization
+  - compared against lxml's production when running in unoptimized Python level
+  - while figuring out [modes to deal with whitespace](https://github.com/delb-xml/delb-py/issues/54)
+
+## 0.6
+
+- a native implementation of the data model
+- add a node type for CDATA
+- move parsing to a separate module with a dummy that still uses lxml as backend
+- provide means to build a wheel with *mypyc*
+- don't publish any wheel of this version
+
+## 0.7
+
+- a native XML parser
+- re-add the argument `parser` for `delb.Document`
+- deprecate `parser_options` of `delb.Document`
+
+## 0.8
+
+- performance optimizations
+- drop any remaining checks against lxml equivalents


### PR DESCRIPTION
i had the opportunity to further investigate the means of production that i had intended to use for a native implementation of this library, namely [Rust](https://rust-lang.org) and [PyO3](pyo3.rs/). that intention was embedded in the concept to implement once in Rust and to then create interfaces for Python and TypeScript for it. here are the takeaways from that recent investigation:

1. PyO3 is noticeably notably evolving which now allowed me to create subclasses (`TagNode` of `NodeBase`), but there are still unsolved issues in that field, the developers are aware of it, but a settled interface will likely still take a while.
1. atm PyO3 is great for functions that take an input and produce an output, but given the harsh contrast of Rust's and Python's memory models it is just clear that an ergonomic facilitation for longer living objects will still take a long time.
1. the intended approach would still require quiet some wrapping and conversion overhead for the Python interface. i assume it won't be much different for the idea of *Rust* -> *WASM* -> *TypeScript*.
1. Rust APIs are generally much different than those of other languages as they usually have variants to access the same object in different manners (owned/borrowed,im-/mutable).
1. at the end i realized that the first prototyping was almost two years old and i was much surprised how well i got grip on it again. so yes, Rust and PyO3 are fun to use.

so the concept for three interfaces backed by one implementation is a failed one. certainly, there's need for a Python interface, there's no obvious need for a Rust one and the TypeScript interface, i hope, could be a building block for text editor enhancements (web, VS Code, other Electron-based apps).

i don't remember the exact occasion, but i stumbled on [mypyc](https://mypyc.readthedocs.io/) that meanwhile gains some traction. the great advantage of it is that it is capable to emit C code from (unlike Cython) pure and mostly "standard idiomatic" Python code.

thus i propose this roadmap for the further development.