### PR TITLE
ci: replaces install of just via snap with setup-just action

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: sudo snap install --edge --classic just
+      - uses: extractions/setup-just@v1
       - run: pip install hatch
       - run: just pytest
 
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - run: sudo snap install --edge --classic just
+      - uses: extractions/setup-just@v1
       - run: pip install hatch
       - run: just ${{ matrix.target }}
 


### PR DESCRIPTION
the [setup-just](https://github.com/extractions/setup-just) action uses [setup-crate](https://github.com/extractions/setup-crate/blob/trunk/setup-crate/src/index.ts) behind the scenes, which appears to simply retrieve a binary release directly from the github releases api. This might end up being faster than installing a snap.