### PR TITLE
Include trimming of former collapse_whitespace in docs 

### DIFF
--- a/_delb/nodes.py
+++ b/_delb/nodes.py
@@ -2258,9 +2258,20 @@ class TagNode(_ElementWrappingNode, NodeBase):
     def merge_text_nodes(self):
         """
         Merges all consecutive text nodes in the subtree into one.
+        Text nodes without content are dropped.
         """
-        for node in self.iterate_descendants(is_text_node):
-            node._merge_appended_text_nodes()
+        with _wrapper_cache:
+            empty_nodes: list[TextNode] = []
+
+            for node in self.iterate_descendants():
+                if not isinstance(node, TextNode):
+                    continue
+                node._merge_appended_text_nodes()
+                if not node.content:
+                    empty_nodes.append(node)
+
+            for node in empty_nodes:
+                node.detach()
 
     @property
     def namespace(self) -> Optional[str]:

--- a/_delb/parser.py
+++ b/_delb/parser.py
@@ -23,8 +23,8 @@ class ParserOptions:
     """
     The configuration options that define an XML parser's behaviour.
 
-    :param collapse_whitespace: :meth:`Collapse the content's whitespace
-                                <delb.Document.collapse_whitespace>`.
+    :param reduce_whitespace: :meth:`Reduce the content's whitespace
+                                <delb.Document.reduce_whitespace>`.
     :param remove_comments: Ignore comments.
     :param remove_processing_instructions: Don't include processing instructions in the
                                            parsed tree.
@@ -34,13 +34,13 @@ class ParserOptions:
 
     def __init__(
         self,
-        collapse_whitespace: bool = False,
+        reduce_whitespace: bool = False,
         remove_comments: bool = False,
         remove_processing_instructions: bool = False,
         resolve_entities: bool = True,
         unplugged: bool = False,
     ):
-        self.collapse_whitespace = collapse_whitespace
+        self.reduce_whitespace = reduce_whitespace
         self.remove_comments = remove_comments
         self.remove_processing_instructions = remove_processing_instructions
         self.resolve_entities = resolve_entities

--- a/delb/__init__.py
+++ b/delb/__init__.py
@@ -334,9 +334,9 @@ class Document(metaclass=DocumentMeta):
         root = _wrapper_cache(loaded_tree.getroot())
         assert isinstance(root, TagNode)
 
-        if config.parser_options.collapse_whitespace:
+        if config.parser_options.reduce_whitespace:
             with altered_default_filters():
-                root._collapse_whitespace()
+                root._reduce_whitespace()
 
         return root
 
@@ -366,15 +366,8 @@ class Document(metaclass=DocumentMeta):
         return result
 
     def collapse_whitespace(self):
-        """
-        Collapses whitespace as described here:
-        https://wiki.tei-c.org/index.php/XML_Whitespace#Recommendations
-
-        Implicitly merges all neighbouring text nodes.
-        """
-        self.merge_text_nodes()
-        with altered_default_filters():
-            self.root._collapse_whitespace()
+        warn("This method was renamed to `reduce_whitespace`.", DeprecationWarning)
+        self.reduce_whitespace()
 
     def css_select(
         self, expression: str, namespaces: Optional[NamespaceDeclarations] = None
@@ -412,6 +405,19 @@ class Document(metaclass=DocumentMeta):
         return self.root.new_tag_node(
             local_name=local_name, attributes=attributes, namespace=namespace
         )
+
+    def reduce_whitespace(self):
+        """
+        Collapses and trims whitespace as described in these `TEI recommendation`_.
+        Text in (sub-)trees with structured data should be trimmed further in
+        subsequent processing.
+        Implicitly merges all neighbouring text nodes.
+
+        .. _TEI recommendation: https://wiki.tei-c.org/index.php/XML_Whitespace
+        """
+        self.merge_text_nodes()
+        with altered_default_filters():
+            self.root._reduce_whitespace()
 
     @property
     def root(self) -> TagNode:

--- a/delb/__init__.py
+++ b/delb/__init__.py
@@ -335,8 +335,7 @@ class Document(metaclass=DocumentMeta):
         assert isinstance(root, TagNode)
 
         if config.parser_options.reduce_whitespace:
-            with altered_default_filters():
-                root._reduce_whitespace()
+            root._reduce_whitespace()
 
         return root
 
@@ -415,9 +414,7 @@ class Document(metaclass=DocumentMeta):
 
         .. _TEI recommendation: https://wiki.tei-c.org/index.php/XML_Whitespace
         """
-        self.merge_text_nodes()
-        with altered_default_filters():
-            self.root._reduce_whitespace()
+        self.root._reduce_whitespace()
 
     @property
     def root(self) -> TagNode:

--- a/integration-tests/test-parse-serialize-equality.py
+++ b/integration-tests/test-parse-serialize-equality.py
@@ -26,7 +26,7 @@ def parse_serialize_compare(file: Path):
 
     try:
         document = Document(
-            file, parser_options=ParserOptions(collapse_whitespace=False)
+            file, parser_options=ParserOptions(reduce_whitespace=False)
         )
     except FailedDocumentLoading as exc:
         print(

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -6,7 +6,6 @@ from delb import (
     Document,
     DocumentMixinBase,
     TagNode,
-    TextNode,
     new_comment_node,
     new_processing_instruction_node,
 )
@@ -27,7 +26,7 @@ def test_clone():
     document.clone()
 
 
-def test_collapse_whitespace():
+def test_reduce_whitespace():
     document = Document(
         """
     <root>
@@ -41,7 +40,7 @@ def test_collapse_whitespace():
     """
     )
 
-    document.collapse_whitespace()
+    document.reduce_whitespace()
     root = document.root
 
     assert root.first_child.full_text == "I Roy - Touting I Self"
@@ -54,15 +53,12 @@ def test_collapse_whitespace():
         '<docImprint><hi rendition="#g">Veröffentlicht im</hi> <docDate>'
         '<hi rendition="#g">Februar</hi> 1848</docDate>.</docImprint>'
     )
-
-    hi_1 = document.root.first_child
-    assert hi_1._etree_obj.tail == " "
-    x = hi_1.fetch_following_sibling()
-    assert isinstance(x, TextNode)
-    assert x.content == " "
-
-    document.collapse_whitespace()
+    document.reduce_whitespace()
     assert document.root.full_text == "Veröffentlicht im Februar 1848."
+
+    document = Document("<root><lb/>Hello <lb/> <lb/> <lb/> world!</root>")
+    document.reduce_whitespace()
+    assert document.root.full_text == "Hello    world!"
 
 
 def test_contains():

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -78,6 +78,7 @@ def test_mro():
     )
 
 
+# see also test_tag_node::test_reduce_whitespace
 def test_reduce_whitespace():
     document = Document(
         """
@@ -107,6 +108,8 @@ def test_reduce_whitespace():
     )
     document.reduce_whitespace()
     assert document.root.full_text == "Veröffentlicht im Februar 1848."
+
+    #
 
     document = Document("<root><lb/>Hello <lb/> <lb/> <lb/> world!</root>")
     document.reduce_whitespace()

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -26,41 +26,6 @@ def test_clone():
     document.clone()
 
 
-def test_reduce_whitespace():
-    document = Document(
-        """
-    <root>
-        <title>
-            I Roy -
-            <hi>Touting I Self</hi>
-        </title>
-        <matrix xml:space="preserve">HB 243 A  Re</matrix>
-        <matrix xml:space="preserve">HB 243 B\tRe</matrix>
-    </root>
-    """
-    )
-
-    document.reduce_whitespace()
-    root = document.root
-
-    assert root.first_child.full_text == "I Roy - Touting I Self"
-    assert root.css_select("matrix")[0].full_text == "HB 243 A  Re"
-    assert root.css_select("matrix")[1].full_text == "HB 243 B\tRe"
-
-    #
-
-    document = Document(
-        '<docImprint><hi rendition="#g">Veröffentlicht im</hi> <docDate>'
-        '<hi rendition="#g">Februar</hi> 1848</docDate>.</docImprint>'
-    )
-    document.reduce_whitespace()
-    assert document.root.full_text == "Veröffentlicht im Februar 1848."
-
-    document = Document("<root><lb/>Hello <lb/> <lb/> <lb/> world!</root>")
-    document.reduce_whitespace()
-    assert document.root.full_text == "Hello    world!"
-
-
 def test_contains():
     document_a = Document("<root><a/></root>")
     document_b = Document("<root><a/></root>")
@@ -113,14 +78,39 @@ def test_mro():
     )
 
 
-def test_set_root():
-    document = Document("<root><node/></root>")
-    document.root = document.root[0].detach()
-    assert str(document) == '<?xml version="1.0" encoding="UTF-8"?><node/>'
+def test_reduce_whitespace():
+    document = Document(
+        """
+    <root>
+        <title>
+            I Roy -
+            <hi>Touting I Self</hi>
+        </title>
+        <matrix xml:space="preserve">HB 243 A  Re</matrix>
+        <matrix xml:space="preserve">HB 243 B\tRe</matrix>
+    </root>
+    """
+    )
 
-    document_2 = Document("<root><replacement/>parts</root>")
-    with pytest.raises(ValueError, match="detached node"):
-        document.root = document_2.root[0]
+    document.reduce_whitespace()
+    root = document.root
+
+    assert root.first_child.full_text == "I Roy - Touting I Self"
+    assert root.css_select("matrix")[0].full_text == "HB 243 A  Re"
+    assert root.css_select("matrix")[1].full_text == "HB 243 B\tRe"
+
+    #
+
+    document = Document(
+        '<docImprint><hi rendition="#g">Veröffentlicht im</hi> <docDate>'
+        '<hi rendition="#g">Februar</hi> 1848</docDate>.</docImprint>'
+    )
+    document.reduce_whitespace()
+    assert document.root.full_text == "Veröffentlicht im Februar 1848."
+
+    document = Document("<root><lb/>Hello <lb/> <lb/> <lb/> world!</root>")
+    document.reduce_whitespace()
+    assert document.root.full_text == "Hello    world!"
 
 
 def test_root_siblings():
@@ -151,6 +141,16 @@ def test_root_siblings():
 
     with pytest.raises(InvalidOperation):
         tail_nodes.pop(0)
+
+
+def test_set_root():
+    document = Document("<root><node/></root>")
+    document.root = document.root[0].detach()
+    assert str(document) == '<?xml version="1.0" encoding="UTF-8"?><node/>'
+
+    document_2 = Document("<root><replacement/>parts</root>")
+    with pytest.raises(ValueError, match="detached node"):
+        document.root = document_2.root[0]
 
 
 def test_xpath(files_path):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -114,7 +114,7 @@ def test_significant_whitespace_is_saved(result_file):
     document.save(result_file, indentation="  ")
 
     assert (
-        Document(result_file, parser_options=ParserOptions(collapse_whitespace=True))
+        Document(result_file, parser_options=ParserOptions(reduce_whitespace=True))
         .xpath("hi")
         .first.fetch_following_sibling()
         == " "
@@ -188,7 +188,7 @@ def test_that_root_siblings_are_preserved(files_path, result_file):
 
 
 def test_transparency(files_path, result_file):
-    parser_options = ParserOptions(collapse_whitespace=False)
+    parser_options = ParserOptions(reduce_whitespace=False)
     for file in (x for x in files_path.glob("[!tei_]*.xml")):
         origin = Document(file, parser_options=parser_options)
         origin.save(result_file)

--- a/tests/test_subclasses.py
+++ b/tests/test_subclasses.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class TEIDocument(Document):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.collapse_whitespace()
+        self.reduce_whitespace()
         self.text_characters = len(self.root.full_text)
 
     @staticmethod

--- a/tests/test_tag_node.py
+++ b/tests/test_tag_node.py
@@ -566,6 +566,14 @@ def test_fetch_preceding_sibling():
     assert a.local_name == "a"
 
 
+# see also test_document::test_reduce_whitespace
+def test_reduce_whitespace():
+    node = new_tag_node("node", children=[""])
+    assert len(node) == 1
+    node._reduce_whitespace()
+    assert len(node) == 0
+
+
 def test_sample_document_structure(sample_document):
     root = sample_document.root
 

--- a/tests/test_tag_node.py
+++ b/tests/test_tag_node.py
@@ -460,6 +460,16 @@ def test_make_node_in_context_with_namespace():
     assert node._etree_obj.tag == "{https://name.space}foo"
 
 
+@pytest.mark.parametrize(
+    ("text_nodes", "expected_count"),
+    (([""], 0), ([" "], 1), ([" ", " "], 1), (["", "", tag("child"), "", ""], 1)),
+)
+def test_merge_text_nodes(text_nodes, expected_count):
+    node = new_tag_node("node", children=text_nodes)
+    node.merge_text_nodes()
+    assert len(node) == expected_count
+
+
 def test_names(sample_document):
     root = sample_document.root
 

--- a/tests/test_text_nodes.py
+++ b/tests/test_text_nodes.py
@@ -172,7 +172,7 @@ def test_bindings(sample_document):
 def test_construction():
     root = Document(
         "<root><node>one</node> two </root>",
-        parser_options=ParserOptions(collapse_whitespace=True),
+        parser_options=ParserOptions(reduce_whitespace=True),
     ).root
     node, two = tuple(x for x in root.iterate_children())
     one = node[0]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -99,7 +99,7 @@ def test_transformation_options():
             <choice><sic>taeteraetae</sic><corr>täterätä</corr></choice>
         </root>
         """,
-        parser_options=ParserOptions(collapse_whitespace=True),
+        parser_options=ParserOptions(reduce_whitespace=True),
     )
     transformation = ResolveChoice()
     result = transformation(document.root)
@@ -116,7 +116,7 @@ def test_transformation_sequence():
             <div copyOf="#d1"/>
         </root>
         """,
-        parser_options=ParserOptions(collapse_whitespace=True),
+        parser_options=ParserOptions(reduce_whitespace=True),
     )
     transformation = TransformationSequence(
         ResolveCopyOf, ResolveChoice(ResolveChoiceOptions(corr=False))
@@ -135,7 +135,7 @@ def test_transformation_sequence_sequence():
             <name>caro</name>
             <name>boudi</name>
         </cast>""",
-        parser_options=ParserOptions(collapse_whitespace=True),
+        parser_options=ParserOptions(reduce_whitespace=True),
     )
     root = Document("<doc><body><ul/></body></doc>").root
     transformation = TransformationSequence(


### PR DESCRIPTION
as the promise of pretty serialization will be that its introduced whitespace would vanish when parsing (with the proper option set), i thought it'd be better to clarify how that inverse operates. beyond the slight rewording i opted for another method / option name. explicitly including trim would yield rather long names.