### PR TITLE
Extends the contents of source distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ dist/
 *.egg-info/
 .idea/
 .mypy_cache/
+*.orig
 pip-wheel-metadata/
 .pytest_cache/
+# in tests/files ; but hatchling doesn't consider a .gitignore there
+.result.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,21 @@ rst-roles = "attr,class,doc,exc,func,meth,obj,ref,term"
 #
 
 [tool.hatch.build.targets.sdist]
-only-include = ["_delb", "delb", "CITATION.cff"]
+only-include = [
+    "benchmarks",
+    "_delb",
+    "delb",
+    "docs",
+    "tests",
+    ".editorconfig",
+    "CHANGES.rst",
+    "CITATION.cff",
+    "delb_logo.svg",
+    "Justfile",
+    "LICENSE.txt",
+    "pyproject.toml",
+    "README.rst",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["_delb", "delb"]

--- a/tests/files/.gitignore
+++ b/tests/files/.gitignore
@@ -1,1 +1,0 @@
-.result.xml


### PR DESCRIPTION
Note that its seemingly hatchling that always adds .gitignore files.

Closes #73.