### PR TITLE
Continuous Integration Optimization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
 
 ...

--- a/.github/scripts/make-github-release.py
+++ b/.github/scripts/make-github-release.py
@@ -1,0 +1,90 @@
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from pypandoc import convert_text, download_pandoc
+
+
+CWD = Path().cwd()
+
+
+date_pattern = r"\(\d\d\d\d-\d\d-\d\d\)"
+version_pattern = r"\d+\.\d+(\.\d+)?(rc\d+)?"
+
+matches_version_header = re.compile(rf"^{version_pattern} {date_pattern}$").match
+
+
+def extract_relevant_contents(expected_version: str) -> str:
+    # This isn't solved with a pandoc filter as pandoc only recognizes the level 3
+    # headers as such.
+
+    line_feed = iter((CWD / "CHANGES.rst").read_text().splitlines())
+
+    while True:
+        line = next(line_feed)
+        if matches_version_header(line) and line.startswith(expected_version):
+            break
+
+    assert next(line_feed)[0] == "-"
+    assert next(line_feed) == ""
+
+    lines: list[str] = []
+    while not matches_version_header(line := next(line_feed)):
+        lines.append(line)
+
+    while lines[-1] == "":
+        lines.pop()
+
+    return "\n".join(lines)
+
+
+def make_github_release(notes: str, version: str):
+    options = []
+    options.extend(["--notes-file", "-"])
+    options.extend(["--title", f"delb {version}"])
+    options.append("--verify-tag")
+    if "rc" in version:
+        options.append("--prerelease")
+
+    result = subprocess.run(
+        [
+            "gh",
+            "release",
+            "create",
+        ]
+        + options
+        + [version],
+        capture_output=True,
+        encoding="utf-8",
+        input=notes,
+    )
+    print(result.stdout)
+    if result.returncode != 0:
+        print(result.stdout)
+    result.check_returncode()
+
+
+def make_release_notes(version: str) -> str:
+    os.environ["DELB_DOCS_BASE_URL"] = f"https://delb.readthedocs.io/en/{version}/"
+    return (
+        convert_text(
+            extract_relevant_contents(version),
+            format="rst",
+            to="markdown_strict",
+            extra_args=["--shift-heading-level-by=1", "--wrap=none"],
+            filters=[".github/scripts/release-notes-pandoc-filter.py"],
+        )
+        + "\n\n----\n\nThe package distributions are available at the "
+        + f"[Python Package Index](https://pypi.org/project/delb/)."
+    )
+
+
+def main(version: str):
+    download_pandoc()
+    make_github_release(notes=make_release_notes(version), version=version)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/.github/scripts/release-notes-pandoc-filter.py
+++ b/.github/scripts/release-notes-pandoc-filter.py
@@ -1,0 +1,59 @@
+import os
+import posixpath
+import sys
+from pathlib import Path
+
+from panflute import run_filter, Code, Link, Str
+from sphinx.util.inventory import InventoryFile
+
+
+BASE_URL = os.environ["DELB_DOCS_BASE_URL"]
+CWD = Path.cwd()
+ROLES_MAPPING = {
+    "attr": "py:attribute",
+    "class": "py:class",
+    "doc": "std:doc",
+    # ?"exception"?: "py:exception",
+    "func": "py:function",
+    "meth": "py:method",
+    "mod": "py:module",
+    # ???: "py:property",
+    "term": "std:term",
+}
+
+
+def bend_links(elem, doc):
+    if not (isinstance(elem, Code) and "interpreted-text" in elem.classes):
+        return elem
+
+    inventory_section = ROLES_MAPPING[elem.attributes["role"]]
+    target = doc.inventory[inventory_section].get(elem.text)
+
+    if target is None:
+        # this is okay for non-existing entries such as :meth:`NodeBase.…` and
+        # objects in other inventories like Python's docs
+        print(f"WARNING: No inventory object for '{elem.text}' found.", file=sys.stderr)
+        return Code(elem.text)
+
+    if (label_text := target[3]) == "-":
+        label_text = elem.text
+
+    if inventory_section.startswith("py:"):
+        label = Code(label_text)
+    else:
+        label = Str(f"„{label_text}”")
+
+    return Link(label, url=target[2])
+
+
+def prepare(doc):
+    with (CWD / "docs" / "build" / "html" / "objects.inv").open("rb") as f:
+        doc.inventory = InventoryFile.load(f, BASE_URL, posixpath.join)
+
+
+def main(doc=None):
+    return run_filter(bend_links, prepare=prepare)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-            python-version: "3.12"
+            python-version: "3.x"
       - run: pipx install hatch
       - run: hatch run docs:linkcheck

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,3 +1,5 @@
+---
+
 name: Check documentation's hyperlinks
 
 on:
@@ -11,6 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-            python-version: "3.x"
+          python-version: "3.x"
       - run: pipx install hatch
       - run: hatch run docs:linkcheck
+
+...

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
             python-version: "3.12"
-      - run: pip install hatch
+      - run: pipx install hatch
       - run: hatch run docs:linkcheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 ---
 
 name: Publish delb
-on:
+on:  # yamllint disable-line
   push:
     tags: ["*"]
 
@@ -21,7 +21,9 @@ jobs:
       name: pypi
       url: https://pypi.org/p/delb
     permissions:
-        id-token: write
+      id-token: write
+      contents: write
+
     steps:
       - name: Download package
         uses: actions/download-artifact@v4
@@ -30,5 +32,13 @@ jobs:
           path: dist
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Install dependencies for creating GH release
+        run: pip install panflute pypandoc sphinx
+      # TODO build docs, so that objects.inv is available
+      - name: Create GH release
+        run: >-
+          python .github/scripts/make-github-release.py ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 ...

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,12 +42,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-          sparse-checkout: 'CHANGES.rst'
-      - name: Install dependencies for creating GH release
-        run: pip install panflute pypandoc sphinx
-      # TODO build docs, so that objects.inv is available
-      - name: Create GH release
-        run: >-
+      - uses: actions/setup-python@v5
+        with:
+          cache: pip
+          python-version: 3.x
+      - uses: extractions/setup-just@v2
+      - run: pipx install hatch
+      - run: just docs
+      - run: pip install panflute pypandoc sphinx
+      - run: >-
           python .github/scripts/make-github-release.py ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 ---
 
 name: Publish delb
-on:  # yamllint disable-line
+on:
   push:
     tags: ["*"]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+---
+
+name: Publish delb
+on:
+  push:
+    tags: ["*"]
+
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/quality-checks.yml
+    with:
+      ref: ${{ env.GITHUB_REF_NAME }}
+
+  upload:
+    name: Publish to the cheeseshop
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: ["build-and-test"]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/delb
+    permissions:
+        id-token: write
+    steps:
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+...

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,8 @@ jobs:
     with:
       ref: ${{ env.GITHUB_REF_NAME }}
 
-  upload:
+  pypi:
     name: Publish to the cheeseshop
-    if: startsWith(github.ref, 'refs/tags/')
     needs: ["build-and-test"]
     runs-on: ubuntu-latest
     environment:
@@ -22,7 +21,6 @@ jobs:
       url: https://pypi.org/p/delb
     permissions:
       id-token: write
-      contents: write
 
     steps:
       - name: Download package
@@ -32,6 +30,19 @@ jobs:
           path: dist
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  github:
+    name: Create a Github release
+    needs: ["build-and-test"]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          sparse-checkout: 'CHANGES.rst'
       - name: Install dependencies for creating GH release
         run: pip install panflute pypandoc sphinx
       # TODO build docs, so that objects.inv is available

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -22,16 +22,24 @@ on:
 
 jobs:
 
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      python-versions: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: hynek/build-and-inspect-python-package@v2
+        id: baipp
+
   unit-tests:
+    needs: ["build"]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-          - 3.8  # 2024-10
-          - 3.9  # 2025-10
-          - "3.10"  # 2026-10
-          - "3.11"  # 2027-10
-          - "3.12"  # 2028-10
+        python-version: ${{ fromJson(needs.build.outputs.python-versions) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,8 +48,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: extractions/setup-just@v2
-      - run: pip install hatch
-      - run: just pytest
+      - run: pipx install hatch
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+      - run: |
+          rm -r _delb delb
+          test "$(find dist -name 'delb-*.whl' | wc -l)" -eq 1
+          export WHEEL_PATH="$(find dist -name 'delb-*.whl')"
+          just pytest
 
   other-quality-checks:
     runs-on: ubuntu-latest
@@ -59,7 +75,7 @@ jobs:
         with:
           python-version: "3.12"
       - uses: extractions/setup-just@v2
-      - run: pip install hatch
+      - run: pipx install hatch
       - run: just ${{ matrix.target }}
 
 ...

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -63,6 +63,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-python@v5
         with:
+          cache: pip
           python-version: ${{ matrix.python-version }}
       - uses: extractions/setup-just@v2
       - run: pipx install hatch
@@ -89,7 +90,8 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          cache: pip
+          python-version: "3.x"
       - uses: extractions/setup-just@v2
       - run: pipx install hatch
       - run: just ${{ matrix.target }}

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -37,6 +37,23 @@ jobs:
   unit-tests:
     needs: ["build"]
     runs-on: ubuntu-latest
+    steps:
+      - uses: extractions/setup-just@v2
+      - run: pipx install hatch
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+      - run: tar xf dist/*.tar.gz --strip-components=1
+      - uses: actions/setup-python@v5
+        with:
+          cache: pip
+          python-version: 3.x
+      - run: just pytest
+
+  compatibility-tests:
+    needs: ["build", "unit-tests"]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ${{ fromJson(needs.build.outputs.python-versions) }}
@@ -56,8 +73,7 @@ jobs:
       - run: |
           rm -r _delb delb
           test "$(find dist -name 'delb-*.whl' | wc -l)" -eq 1
-          export WHEEL_PATH="$(find dist -name 'delb-*.whl')"
-          just pytest
+          just test-wheel "$(find dist -name 'delb-*.whl')"
 
   other-quality-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -25,7 +25,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      python-versions: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
+      python-versions: >-
+        ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
 
     steps:
       - uses: actions/checkout@v4
@@ -81,8 +82,8 @@ jobs:
     strategy:
       matrix:
         target:
-          - code-lint
           - doctest
+          - lint
           - mypy
     steps:
       - uses: actions/checkout@v4

--- a/Justfile
+++ b/Justfile
@@ -2,11 +2,10 @@ default: tests
 
 
 version := `hatch version`
-ci-suffix := if env_var_or_default("CI", "false") == "true" { "-ci" } else { "" }
 
 _assert_no_dev_version:
   #!/usr/bin/env python3
-  if "-dev" in "{{version}}":
+  if "dev" in "{{version}}":
     raise SystemExit(1)
 
 # run benchmarks
@@ -41,7 +40,7 @@ mypy:
 
 # run the complete testsuite
 pytest:
-    hatch run unit-tests{{ci-suffix}}:check
+    hatch run unit-tests:check
 
 # release the current version on github & (transitively) the PyPI
 release: _assert_no_dev_version tests
@@ -62,6 +61,10 @@ show-docs: docs
 
 # run all tests on normalized code
 tests: black code-lint mypy pytest doctest
+
+# run the testsuite against a wheel (installed from $WHEEL_PATH); intended to run on a CI platform
+test-wheel wheel_path:
+    hatch run test-wheel:check {{wheel_path}}
 
 # Generates and validates CITATION.cff
 update-citation-file:

--- a/Justfile
+++ b/Justfile
@@ -63,8 +63,8 @@ show-docs: docs
 tests: black code-lint mypy pytest doctest
 
 # run the testsuite against a wheel (installed from $WHEEL_PATH); intended to run on a CI platform
-test-wheel wheel_path:
-    hatch run test-wheel:check {{wheel_path}}
+test-wheel $WHEEL_PATH:
+    hatch run test-wheel:check
 
 # Generates and validates CITATION.cff
 update-citation-file:

--- a/Justfile
+++ b/Justfile
@@ -20,10 +20,6 @@ black:
 coverage-report:
     hatch run unit-tests:coverage-report
 
-# code linting with flake8
-code-lint:
-    hatch run linting:check
-
 # generate Sphinx HTML documentation, including API docs
 docs:
     hatch run docs:clean
@@ -33,6 +29,11 @@ docs:
 doctest:
     hatch run docs:clean
     hatch run docs:doctest
+
+# code & data linting with flake8 & yamllint
+lint:
+    hatch run linting:check
+    pipx run yamllint $(find . -name "*.yaml" -or -name "*.yml")
 
 # run static type checks with mypy
 mypy:
@@ -60,7 +61,7 @@ show-docs: docs
     xdg-open docs/build/html/index.html
 
 # run all tests on normalized code
-tests: black code-lint mypy pytest doctest
+tests: black lint mypy pytest doctest
 
 # run the testsuite against a wheel (installed from $WHEEL_PATH); intended to run on a CI platform
 test-wheel $WHEEL_PATH:

--- a/Justfile
+++ b/Justfile
@@ -2,7 +2,7 @@ default: tests
 
 
 version := `hatch version`
-
+ci-suffix := if env_var_or_default("CI", "false") == "true" { "-ci" } else { "" }
 
 # run benchmarks
 benchmarks:
@@ -36,7 +36,7 @@ mypy:
 
 # run the complete testsuite
 pytest:
-    hatch run unit-tests:check
+    hatch run unit-tests{{ci-suffix}}:check
 
 # release the current version on github & the PyPI
 release: tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ coverage-report = """
 template = "unit-tests"
 skip-install = true
 extra-dependencies = [
-    "delb @ {root:uri}/{args}",
+    "delb @ {root:uri}/{env:WHEEL_PATH}",
 ]
 [tool.hatch.envs.test-wheel.scripts]
 check = "python -m pytest tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,3 +205,10 @@ coverage-report = """
         --cov=_delb --cov=delb \
         tests
 """
+
+[tool.hatch.envs.unit-tests-ci]
+template = "unit-tests"
+skip-install = true
+extra-dependencies = [
+    "delb @ {root:uri}/{env:WHEEL_PATH}"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,9 +206,11 @@ coverage-report = """
         tests
 """
 
-[tool.hatch.envs.unit-tests-ci]
+[tool.hatch.envs.test-wheel]
 template = "unit-tests"
 skip-install = true
 extra-dependencies = [
-    "delb @ {root:uri}/{env:WHEEL_PATH}"
+    "delb @ {root:uri}/{args}",
 ]
+[tool.hatch.envs.test-wheel.scripts]
+check = "python -m pytest tests"


### PR DESCRIPTION
okay, so here's changes for the CI:

- tests run against installed wheel, not an editable install
- also the source distribution is build and validated as the wheel
- the declared trove classifiers drive the interpreter selection to run tests against
- tag pushes trigger a workflow that uploads the packages directly(?) to the PyPI

however due to the change of package installation (actually the non-presence of the pure source) the coverage count reports less which leads to a fail of the expected goal. all of these possible solutions i don't like:

- decrease the expectation; as local runs are more likely to re-define the expectation
- increasing test coverage; inefficient now. if this just happens now it's okay, but it will be an actual matter before optimizations are seeked way later in the project
- adding a test based on the source distribution; that'd suggest to use the test files from that dist as well, but that then creates the requirement to test that the source dist is complete, doable, but i don't imagine this to be more of a nag than practical
- define two different goals; just no